### PR TITLE
Fix: Adjusting the text alignment in details error.

### DIFF
--- a/details/implementation/src/main/kotlin/com/will/details/implementation/presentation/composable/components/DetailsScreenError.kt
+++ b/details/implementation/src/main/kotlin/com/will/details/implementation/presentation/composable/components/DetailsScreenError.kt
@@ -25,7 +25,9 @@ import com.will.details.implementation.presentation.viewmodel.DetailsUiActionInv
 @Composable
 internal fun DetailsScreenError(error: ProductDetailsError, onUiAction: DetailsUiActionInvoke) {
     Scaffold(
-        modifier = Modifier.fillMaxSize().testTag("details-error"),
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag("details-error"),
         topBar = {
             Header(title = stringResource(R.string.product_details_title_label)) {
                 onUiAction(DetailsUiAction.OnBackClicked)
@@ -39,7 +41,11 @@ internal fun DetailsScreenError(error: ProductDetailsError, onUiAction: DetailsU
                 .fillMaxSize(),
             verticalArrangement = Arrangement.Center
         ) {
-            Text(text = stringResource(error.messageResId), textAlign = TextAlign.Center)
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(error.messageResId),
+                textAlign = TextAlign.Center
+            )
 
             error.buttonLabelResId?.let {
                 PrimaryButton(

--- a/details/implementation/src/test/snapshots/images/com.will.details.implementation.presentation.composable.components_InfoSectionComponentTest_validateExpandedComponent.png
+++ b/details/implementation/src/test/snapshots/images/com.will.details.implementation.presentation.composable.components_InfoSectionComponentTest_validateExpandedComponent.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cb87f6e800316e372e04627b2eb1ca23376ea777f93e7e653bdaa8fbe43c16ec
-size 5616
+oid sha256:e6775aa506074a2161bda4adf79478928c3da0928272ca7cc3d9bf64f4011901
+size 5651


### PR DESCRIPTION
### Checklist

- [x] A compilação foi bem sucedida?
- [ ] Contém testes unitários?
- [x] Contém testes de ui?


### Descrição do PR
O texto da tela de erro do detalhes do produto não estava ficando centralizado, foi feito ajuste.

### Evidência
![image](https://github.com/user-attachments/assets/cea5692f-32fa-4a2d-868d-482eadbbdad8)

